### PR TITLE
Null pointer check and height value check

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3242,12 +3242,14 @@ bool ProcessNewBlock(CValidationState &state, CNode* pfrom, CBlock* pblock, bool
 
 bool TestBlockValidity(CValidationState &state, const CBlock& block, CBlockIndex * const pindexPrev, bool fCheckPOW, bool fCheckMerkleRoot)
 {
+    if(pindexPrev == NULL) return false;
     AssertLockHeld(cs_main);
     assert(pindexPrev == chainActive.Tip());
 
     CCoinsViewCache viewNew(pcoinsTip);
     CBlockIndex indexDummy(block);
     indexDummy.pprev = pindexPrev;
+    if(pindexPrev->nHeight < 0) return false;
     indexDummy.nHeight = pindexPrev->nHeight + 1;
 
     // NOTE: CheckBlockHeader is called by CheckBlock


### PR DESCRIPTION
Checks if pindexPrev is null and checks, as well, if pindexPrev->nHeight is smaller than 0.